### PR TITLE
Allow setting timeoutInterval for POST requests. (iOS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Accept all SSL certificates.  Or disable accepting all certificates.
     });
     
 ### post<a name="post"></a>
-Execute a POST request.  Takes a URL, parameters, and headers.
+Execute a POST request.  Takes a URL, parameters, headers, and optional timeoutInterval (default is 60 sec).
 
 #### success
 The success function receives a response object with 2 properties: status and data.  Status is the HTTP response code and data is the response from the server as a string. Here's a quick example:

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
   xmlns:android="http://schemas.android.com/apk/res/android"
   id="com.synconset.cordovaHTTP"
-  version="0.1.1">
+  version="0.1.2">
 
     <name>SSL Pinning</name>
  

--- a/src/ios/CordovaHttpPlugin.m
+++ b/src/ios/CordovaHttpPlugin.m
@@ -76,10 +76,17 @@
    NSString *url = [command.arguments objectAtIndex:0];
    NSDictionary *parameters = [command.arguments objectAtIndex:1];
    NSDictionary *headers = [command.arguments objectAtIndex:2];
+   NSString *timeoutIntervalString = [command.arguments objectAtIndex:3];
    [self setRequestHeaders: headers];
    
    CordovaHttpPlugin* __weak weakSelf = self;
    manager.responseSerializer = [TextResponseSerializer serializer];
+   if (timeoutIntervalString != (id)[NSNull null]) {
+      float timeoutInterval = [timeoutIntervalString floatValue];
+      if (timeoutInterval > 0) {
+        manager.requestSerializer.timeoutInterval = timeoutInterval;
+      }
+   }
    [manager POST:url parameters:parameters success:^(AFHTTPRequestOperation *operation, id responseObject) {
       NSMutableDictionary *dictionary = [NSMutableDictionary dictionary];
       [dictionary setObject:[NSNumber numberWithInt:operation.response.statusCode] forKey:@"status"];

--- a/www/cordovaHTTP.js
+++ b/www/cordovaHTTP.js
@@ -19,8 +19,8 @@ var http = {
     acceptAllCerts: function(allow, success, failure) {
         return exec(success, failure, "CordovaHttpPlugin", "acceptAllCerts", [allow]);
     },
-    post: function(url, params, headers, success, failure) {
-        return exec(success, failure, "CordovaHttpPlugin", "post", [url, params, headers]);
+    post: function(url, params, headers, timeoutInterval, success, failure) {
+        return exec(success, failure, "CordovaHttpPlugin", "post", [url, params, headers, timeoutInterval]);
     },
     get: function(url, params, headers, success, failure) {
         return exec(success, failure, "CordovaHttpPlugin", "get", [url, params, headers]);
@@ -109,8 +109,8 @@ if (typeof angular !== "undefined") {
             acceptAllCerts: function(allow) {
                 return makePromise(http.acceptAllCerts, [allow]);
             },
-            post: function(url, params, headers) {
-                return makePromise(http.post, [url, params, headers], true);
+            post: function(url, params, headers, timeoutInterval) {
+                return makePromise(http.post, [url, params, headers, timeoutInterval], true);
             },
             get: function(url, params, headers) {
                 return makePromise(http.get, [url, params, headers], true);


### PR DESCRIPTION
Added an optional parameter, `timeoutInterval`,  to `post()`. If the parameter is not null and can be cast to a float greater than zero, it is used as the timeout interval for the POST request. 
