### PR TITLE
Disables encoding get() URLs by default

### DIFF
--- a/src/android/com/synconset/CordovaHTTP/CordovaHttpGet.java
+++ b/src/android/com/synconset/CordovaHTTP/CordovaHttpGet.java
@@ -51,6 +51,8 @@ public class CordovaHttpGet extends CordovaHttp implements Runnable {
         } catch (HttpRequestException e) {
             if (e.getCause() instanceof UnknownHostException) {
                 this.respondWithError(0, "The host could not be resolved");
+            } else if (e.getCause() instanceof SSLHandshakeException) {
+                this.respondWithError("SSL handshake failed");
             } else {
                 this.respondWithError("There was an error with the request");
             }


### PR DESCRIPTION
IGNORE... wrong chage set in PR
