### PR TITLE
Disables encoding get() URLs by default (android)

### DIFF
--- a/src/android/com/synconset/CordovaHTTP/CordovaHttpGet.java
+++ b/src/android/com/synconset/CordovaHTTP/CordovaHttpGet.java
@@ -31,7 +31,7 @@ public class CordovaHttpGet extends CordovaHttp implements Runnable {
     @Override
     public void run() {
         try {
-            HttpRequest request = HttpRequest.get(this.getUrlString(), this.getParams(), true);
+            HttpRequest request = HttpRequest.get(this.getUrlString(), this.getParams(), false);
             this.setupSecurity(request);
             request.acceptCharset(CHARSET);
             request.headers(this.getHeaders());


### PR DESCRIPTION
(real pull request, sorry about the other)

In our app this is leading to errors on URLs that are already properly encoded (they are being double-encoded... %20 -> %2520, etc)

Feel free to ignore or close this one if you need this functionality, but since `post()` URLs were *not* being encoded, I thought it might have just been a default that didn't affect you one way or the other.