### PR TITLE
Reports SSL Handshake errors when they occur (android)

### DIFF
--- a/src/android/com/synconset/CordovaHTTP/CordovaHttpDownload.java
+++ b/src/android/com/synconset/CordovaHTTP/CordovaHttpDownload.java
@@ -57,6 +57,8 @@ public class CordovaHttpDownload extends CordovaHttp implements Runnable {
         } catch (HttpRequestException e) {
             if (e.getCause() instanceof UnknownHostException) {
                 this.respondWithError(0, "The host could not be resolved");
+            } else if (e.getCause() instanceof SSLHandshakeException) {
+                this.respondWithError("SSL handshake failed");
             } else {
                 this.respondWithError("There was an error with the request");
             }

--- a/src/android/com/synconset/CordovaHTTP/CordovaHttpGet.java
+++ b/src/android/com/synconset/CordovaHTTP/CordovaHttpGet.java
@@ -51,6 +51,8 @@ public class CordovaHttpGet extends CordovaHttp implements Runnable {
         } catch (HttpRequestException e) {
             if (e.getCause() instanceof UnknownHostException) {
                 this.respondWithError(0, "The host could not be resolved");
+            } else if (e.getCause() instanceof SSLHandshakeException) {
+                this.respondWithError("SSL handshake failed");
             } else {
                 this.respondWithError("There was an error with the request");
             }

--- a/src/android/com/synconset/CordovaHTTP/CordovaHttpPost.java
+++ b/src/android/com/synconset/CordovaHTTP/CordovaHttpPost.java
@@ -44,6 +44,8 @@ public class CordovaHttpPost extends CordovaHttp implements Runnable {
         }  catch (HttpRequestException e) {
             if (e.getCause() instanceof UnknownHostException) {
                 this.respondWithError(0, "The host could not be resolved");
+            } else if (e.getCause() instanceof SSLHandshakeException) {
+                this.respondWithError("SSL handshake failed");
             } else {
                 this.respondWithError("There was an error with the request");
             }

--- a/src/android/com/synconset/CordovaHTTP/CordovaHttpUpload.java
+++ b/src/android/com/synconset/CordovaHTTP/CordovaHttpUpload.java
@@ -83,6 +83,8 @@ public class CordovaHttpUpload extends CordovaHttp implements Runnable {
         }  catch (HttpRequestException e) {
             if (e.getCause() instanceof UnknownHostException) {
                 this.respondWithError(0, "The host could not be resolved");
+            } else if (e.getCause() instanceof SSLHandshakeException) {
+                this.respondWithError("SSL handshake failed");
             } else {
                 this.respondWithError("There was an error with the request");
             }


### PR DESCRIPTION
Instead of just reporting a 500 error with some generic text, I thought it might be useful to know when an actual SSL related error occurred. It the idea is to prevent MitM attacks, it might be important to warn users it might be happening.

Currently doesn't drill down the `getCause()` tree very far, just determines if it was an `SSLHandshakeException`.

Another optional pull request (thus no corresponding issue)
