### PR TITLE
Exporting http object to use it through clobbers target defined .

### DIFF
--- a/www/cordovaHTTP.js
+++ b/www/cordovaHTTP.js
@@ -63,6 +63,8 @@ var http = {
     }
 };
 
+module.exports = http;
+
 if (typeof angular !== "undefined") {
     angular.module('cordovaHTTP', []).factory('cordovaHTTP', function($timeout, $q) {
         function makePromise(fn, args, async) {


### PR DESCRIPTION
Doing this helps in using the plugin through ngCordova, a much better way of using Cordova plugins from Angular.
