### PR TITLE
Add CFNetwork and SystemConfiguration frameworks to plugin.xml for iOS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 cordovaHTTP
-==================
+===========
 
 Cordova / Phonegap plugin for communicating with HTTP servers.  Supports iOS and Android.
 
@@ -19,17 +19,22 @@ using the Cordova / Phonegap command line interface.
 
 ## Usage
 
+### Regular JavaScript
+
+This plugin registers as `cordova.plugins.cordovaHTTP` (and also as a global `window.cordovaHTTP`).
+
 ### AngularJS
 
-This plugin creates a cordovaHTTP service inside of a cordovaHTTP module.  You must load the module when you create your app's module.
+There is [ngCordovaHTTP](https://github.com/panta/ngCordovaHTTP), an AngularJS module for this plugin. Install it with `bower`:
 
-    var app = angular.module('myApp', ['ngRoute', 'ngAnimate', 'cordovaHTTP']);
-    
-You can then inject the cordovaHTTP service into your controllers.  The functions can then be used identically to the examples shown below except that instead of accepting success and failure callback functions, each function returns a promise.  For more information on promises in AngularJS read the [AngularJS docs](http://docs.angularjs.org/api/ng/service/$q).  For more info on promises in general check out this article on [html5rocks](http://www.html5rocks.com/en/tutorials/es6/promises/).  Make sure that you load cordova.js or phonegap.js after AngularJS is loaded.
+    bower install ngCordovaHTTP --save-dev
 
-### Not AngularJS
+The AngularJS module will be available as `ngCordovaHTTP`, providing a `cordovaHTTP` service.
+You must load the module when you create your app's module.
 
-This plugin registers a `cordovaHTTP` global on window
+    var app = angular.module('myApp', ['ngRoute', 'ngAnimate', 'ngCordovaHTTP']);
+
+You can then inject the `cordovaHTTP` service into your controllers.  The functions can then be used identically to the examples shown below except that instead of accepting success and failure callback functions, each function returns a promise.  For more information on promises in AngularJS read the [AngularJS docs](http://docs.angularjs.org/api/ng/service/$q).  For more info on promises in general check out this article on [html5rocks](http://www.html5rocks.com/en/tutorials/es6/promises/).  Make sure that you load cordova.js or phonegap.js after AngularJS is loaded.
 
 
 ## Functions

--- a/plugin.xml
+++ b/plugin.xml
@@ -67,6 +67,8 @@
         <source-file src="src/ios/AFNetworking/AFURLSessionManager.m" />
 
         <framework src="Security.framework" />
+        <framework src="CFNetwork.framework" />
+        <framework src="SystemConfiguration.framework" />
     </platform>
 
     <!--android -->

--- a/plugin.xml
+++ b/plugin.xml
@@ -17,7 +17,7 @@
     <dependency id="org.apache.cordova.file" url="https://github.com/apache/cordova-plugin-file" commit="r0.2.5" />
 
     <js-module src="www/cordovaHTTP.js" name="CordovaHttpPlugin">
-        <clobbers target="plugins.CordovaHttpPlugin" />
+        <clobbers target="cordova.plugins.cordovaHTTP" />
     </js-module>
 
     <!-- ios -->

--- a/src/ios/TextResponseSerializer.m
+++ b/src/ios/TextResponseSerializer.m
@@ -23,7 +23,7 @@ static BOOL AFErrorOrUnderlyingErrorHasCode(NSError *error, NSInteger code) {
         return nil;
     }
 
-    self.acceptableContentTypes = [NSSet setWithObjects:@"text/plain", @"text/html", @"text/json", @"application/json", @"text/xml", @"application/xml", @"text/css", nil];
+    self.acceptableContentTypes = [NSSet setWithObjects:@"text/plain", @"text/html", @"text/json", @"text/javascript", @"application/json", @"application/javascript", @"text/xml", @"application/xml", @"text/css", nil];
 
     return self;
 }

--- a/www/cordovaHTTP.js
+++ b/www/cordovaHTTP.js
@@ -4,128 +4,72 @@
  * An HTTP Plugin for PhoneGap.
  */
 
-var exec = require('cordova/exec');
+var PluginLoader = function (require, exports, module) {
 
-var http = {
-    useBasicAuth: function(username, password, success, failure) {
-        return exec(success, failure, "CordovaHttpPlugin", "useBasicAuth", [username, password]);
-    },
-    setHeader: function(header, value, success, failure) {
-        return exec(success, failure, "CordovaHttpPlugin", "setHeader", [header, value]);
-    },
-    enableSSLPinning: function(enable, success, failure) {
-        return exec(success, failure, "CordovaHttpPlugin", "enableSSLPinning", [enable]);
-    },
-    acceptAllCerts: function(allow, success, failure) {
-        return exec(success, failure, "CordovaHttpPlugin", "acceptAllCerts", [allow]);
-    },
-    post: function(url, params, headers, success, failure) {
-        return exec(success, failure, "CordovaHttpPlugin", "post", [url, params, headers]);
-    },
-    get: function(url, params, headers, success, failure) {
-        return exec(success, failure, "CordovaHttpPlugin", "get", [url, params, headers]);
-    },
-    uploadFile: function(url, params, headers, filePath, name, success, failure) {
-        return exec(success, failure, "CordovaHttpPlugin", "uploadFile", [url, params, headers, filePath, name]);
-    },
-    downloadFile: function(url, params, headers, filePath, success, failure) {
-        /*
-         *
-         * Licensed to the Apache Software Foundation (ASF) under one
-         * or more contributor license agreements.  See the NOTICE file
-         * distributed with this work for additional information
-         * regarding copyright ownership.  The ASF licenses this file
-         * to you under the Apache License, Version 2.0 (the
-         * "License"); you may not use this file except in compliance
-         * with the License.  You may obtain a copy of the License at
-         *
-         *   http://www.apache.org/licenses/LICENSE-2.0
-         *
-         * Unless required by applicable law or agreed to in writing,
-         * software distributed under the License is distributed on an
-         * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-         * KIND, either express or implied.  See the License for the
-         * specific language governing permissions and limitations
-         * under the License.
-         *
-         * Modified by Andrew Stephan for Sync OnSet
-         *
-        */
-        var win = function(result) {
-            var entry = new (require('org.apache.cordova.file.FileEntry'))();
-            entry.isDirectory = false;
-            entry.isFile = true;
-            entry.name = result.file.name;
-            entry.fullPath = result.file.fullPath;
-            success(entry);
-        };
-        return exec(win, failure, "CordovaHttpPlugin", "downloadFile", [url, params, headers, filePath]);
-    }
-};
+    var exec = require('cordova/exec');
 
-module.exports = http;
-
-if (typeof angular !== "undefined") {
-    angular.module('cordovaHTTP', []).factory('cordovaHTTP', function($timeout, $q) {
-        function makePromise(fn, args, async) {
-            var deferred = $q.defer();
-            
-            var success = function(response) {
-                if (async) {
-                    $timeout(function() {
-                        deferred.resolve(response);
-                    });
-                } else {
-                    deferred.resolve(response);
-                }
+    var http = {
+        useBasicAuth: function(username, password, success, failure) {
+            return exec(success, failure, "CordovaHttpPlugin", "useBasicAuth", [username, password]);
+        },
+        setHeader: function(header, value, success, failure) {
+            return exec(success, failure, "CordovaHttpPlugin", "setHeader", [header, value]);
+        },
+        enableSSLPinning: function(enable, success, failure) {
+            return exec(success, failure, "CordovaHttpPlugin", "enableSSLPinning", [enable]);
+        },
+        acceptAllCerts: function(allow, success, failure) {
+            return exec(success, failure, "CordovaHttpPlugin", "acceptAllCerts", [allow]);
+        },
+        post: function(url, params, headers, success, failure) {
+            return exec(success, failure, "CordovaHttpPlugin", "post", [url, params, headers]);
+        },
+        get: function(url, params, headers, success, failure) {
+            return exec(success, failure, "CordovaHttpPlugin", "get", [url, params, headers]);
+        },
+        uploadFile: function(url, params, headers, filePath, name, success, failure) {
+            return exec(success, failure, "CordovaHttpPlugin", "uploadFile", [url, params, headers, filePath, name]);
+        },
+        downloadFile: function(url, params, headers, filePath, success, failure) {
+            /*
+             *
+             * Licensed to the Apache Software Foundation (ASF) under one
+             * or more contributor license agreements.  See the NOTICE file
+             * distributed with this work for additional information
+             * regarding copyright ownership.  The ASF licenses this file
+             * to you under the Apache License, Version 2.0 (the
+             * "License"); you may not use this file except in compliance
+             * with the License.  You may obtain a copy of the License at
+             *
+             *   http://www.apache.org/licenses/LICENSE-2.0
+             *
+             * Unless required by applicable law or agreed to in writing,
+             * software distributed under the License is distributed on an
+             * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+             * KIND, either express or implied.  See the License for the
+             * specific language governing permissions and limitations
+             * under the License.
+             *
+             * Modified by Andrew Stephan for Sync OnSet
+             *
+            */
+            var win = function(result) {
+                var entry = new (require('org.apache.cordova.file.FileEntry'))();
+                entry.isDirectory = false;
+                entry.isFile = true;
+                entry.name = result.file.name;
+                entry.fullPath = result.file.fullPath;
+                success(entry);
             };
-            
-            var fail = function(response) {
-                if (async) {
-                    $timeout(function() {
-                        deferred.reject(response);
-                    });
-                } else {
-                    deferred.reject(response);
-                }
-            };
-            
-            args.push(success);
-            args.push(fail);
-            
-            fn.apply(http, args);
-            
-            return deferred.promise;
+            return exec(win, failure, "CordovaHttpPlugin", "downloadFile", [url, params, headers, filePath]);
         }
-        
-        var cordovaHTTP = {
-            useBasicAuth: function(username, password) {
-                return makePromise(http.useBasicAuth, [username, password]);
-            },
-            setHeader: function(header, value) {
-                return makePromise(http.setHeader, [header, value]);
-            },
-            enableSSLPinning: function(enable) {
-                return makePromise(http.enableSSLPinning, [enable]);
-            },
-            acceptAllCerts: function(allow) {
-                return makePromise(http.acceptAllCerts, [allow]);
-            },
-            post: function(url, params, headers) {
-                return makePromise(http.post, [url, params, headers], true);
-            },
-            get: function(url, params, headers) {
-                return makePromise(http.get, [url, params, headers], true);
-            },
-            uploadFile: function(url, params, headers, filePath, name) {
-                return makePromise(http.uploadFile, [url, params, headers, filePath, name], true);
-            },
-            downloadFile: function(url, params, headers, filePath) {
-                return makePromise(http.downloadFile, [url, params, headers, filePath], true);
-            }
-        };
-        return cordovaHTTP;
-    });
-} else {
+    };
+
+    module.exports = http;
+
     window.cordovaHTTP = http;
 }
+
+PluginLoader(require, exports, module);
+
+cordova.define("cordova/plugin/cordovaHTTP", PluginLoader);


### PR DESCRIPTION
This seems to be needed with at least cordova 4.1.2 and ios platform 3.7.0, to avoid "Undefined symbols" errors when linking agains the plugin.
