### PR TITLE
update cordova file plugin dependency

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -14,7 +14,7 @@
         <engine name="cordova" version=">=3.0.0" />
     </engines>
 
-    <dependency id="org.apache.cordova.file" url="https://github.com/apache/cordova-plugin-file" commit="r0.2.5" />
+    <dependency id="cordova-plugin-file" version=">=2.0.0" />
 
     <js-module src="www/cordovaHTTP.js" name="CordovaHttpPlugin">
         <clobbers target="plugins.CordovaHttpPlugin" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -85,6 +85,7 @@
         <source-file src="src/android/com/synconset/CordovaHTTP/CordovaHttp.java" target-dir="src/com/synconset" />
         <source-file src="src/android/com/synconset/CordovaHTTP/CordovaHttpGet.java" target-dir="src/com/synconset" />
         <source-file src="src/android/com/synconset/CordovaHTTP/CordovaHttpPost.java" target-dir="src/com/synconset" />
+        <source-file src="src/android/com/synconset/CordovaHTTP/CordovaHttpHead.java" target-dir="src/com/synconset" />
         <source-file src="src/android/com/synconset/CordovaHTTP/CordovaHttpUpload.java" target-dir="src/com/synconset" />
         <source-file src="src/android/com/synconset/CordovaHTTP/CordovaHttpDownload.java" target-dir="src/com/synconset" />
         <source-file src="src/android/com/synconset/CordovaHTTP/CordovaHttpPlugin.java" target-dir="src/com/synconset" />

--- a/src/android/com/synconset/CordovaHTTP/CordovaHttp.java
+++ b/src/android/com/synconset/CordovaHTTP/CordovaHttp.java
@@ -35,7 +35,8 @@ public abstract class CordovaHttp {
     
     private static AtomicBoolean sslPinning = new AtomicBoolean(false);
     private static AtomicBoolean acceptAllCerts = new AtomicBoolean(false);
-    
+    private static AtomicBoolean acceptAllHosts = new AtomicBoolean(false);
+
     private String urlString;
     private Map<?, ?> params;
     private Map<String, String> headers;
@@ -61,7 +62,11 @@ public abstract class CordovaHttp {
             sslPinning.set(false);
         }
     }
-    
+
+    public static void acceptAllHosts(boolean accept) {
+        acceptAllHosts.set(accept);
+    }
+
     protected String getUrlString() {
         return this.urlString;
     }
@@ -81,10 +86,11 @@ public abstract class CordovaHttp {
     protected HttpRequest setupSecurity(HttpRequest request) {
         if (acceptAllCerts.get()) {
             request.trustAllCerts();
-            request.trustAllHosts();
+            request.trustAllHosts(true);
         }
         if (sslPinning.get()) {
             request.pinToCerts();
+            request.trustAllHosts(acceptAllHosts.get());
         }
         return request;
     }

--- a/src/android/com/synconset/CordovaHTTP/CordovaHttp.java
+++ b/src/android/com/synconset/CordovaHTTP/CordovaHttp.java
@@ -12,6 +12,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.BufferedReader;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -108,5 +110,18 @@ public abstract class CordovaHttp {
     
     protected void respondWithError(String msg) {
         this.respondWithError(500, msg);
+    }
+
+    protected void addResponseHeaders(HttpRequest request, JSONObject response) throws JSONException {
+        Map<String, List<String>> headers = request.headers();
+        Map<String, String> parsed_headers = new HashMap<String, String>();
+        for (Map.Entry<String, List<String>> entry : headers.entrySet()) {
+            String key = entry.getKey();
+            List<String> value = entry.getValue();
+            if ((key != null) && (!value.isEmpty())) {
+                parsed_headers.put(key, value.get(0));
+            }
+        }
+        response.put("headers", new JSONObject(parsed_headers));
     }
 }

--- a/src/android/com/synconset/CordovaHTTP/CordovaHttpDownload.java
+++ b/src/android/com/synconset/CordovaHTTP/CordovaHttpDownload.java
@@ -40,6 +40,7 @@ public class CordovaHttpDownload extends CordovaHttp implements Runnable {
             int code = request.code();
             
             JSONObject response = new JSONObject();
+            this.addResponseHeaders(request, response);
             response.put("status", code);
             if (code >= 200 && code < 300) {
                 URI uri = new URI(filePath);

--- a/src/android/com/synconset/CordovaHTTP/CordovaHttpDownload.java
+++ b/src/android/com/synconset/CordovaHTTP/CordovaHttpDownload.java
@@ -45,7 +45,7 @@ public class CordovaHttpDownload extends CordovaHttp implements Runnable {
                 URI uri = new URI(filePath);
                 File file = new File(uri);
                 request.receive(file);
-                JSONObject fileEntry = FileUtils.getEntry(file);
+                JSONObject fileEntry = FileUtils.getFilePlugin().getEntryForFile(file);
                 response.put("file", fileEntry);
                 this.getCallbackContext().success(response);
             } else {

--- a/src/android/com/synconset/CordovaHTTP/CordovaHttpGet.java
+++ b/src/android/com/synconset/CordovaHTTP/CordovaHttpGet.java
@@ -40,6 +40,7 @@ public class CordovaHttpGet extends CordovaHttp implements Runnable {
             int code = request.code();
             String body = request.body(CHARSET);
             JSONObject response = new JSONObject();
+            this.addResponseHeaders(request, response);
             response.put("status", code);
             if (code >= 200 && code < 300) {
                 response.put("data", body);

--- a/src/android/com/synconset/CordovaHTTP/CordovaHttpHead.java
+++ b/src/android/com/synconset/CordovaHTTP/CordovaHttpHead.java
@@ -3,48 +3,55 @@
  */
 package com.synconset;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.net.UnknownHostException;
 import java.util.Map;
+
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.HostnameVerifier;
+
+import javax.net.ssl.SSLHandshakeException;
 
 import org.apache.cordova.CallbackContext;
 import org.json.JSONException;
 import org.json.JSONObject;
-
-import javax.net.ssl.SSLHandshakeException;
 
 import android.util.Log;
 
 import com.github.kevinsawicki.http.HttpRequest;
 import com.github.kevinsawicki.http.HttpRequest.HttpRequestException;
  
-public class CordovaHttpPost extends CordovaHttp implements Runnable {
-    public CordovaHttpPost(String urlString, Map<?, ?> params, Map<String, String> headers, CallbackContext callbackContext) {
+public class CordovaHttpHead extends CordovaHttp implements Runnable {
+    public CordovaHttpHead(String urlString, Map<?, ?> params, Map<String, String> headers, CallbackContext callbackContext) {
         super(urlString, params, headers, callbackContext);
     }
     
     @Override
     public void run() {
         try {
-            HttpRequest request = HttpRequest.post(this.getUrlString());
+            HttpRequest request = HttpRequest.head(this.getUrlString(), this.getParams(), true);
             this.setupSecurity(request);
             request.acceptCharset(CHARSET);
             request.headers(this.getHeaders());
-            request.form(this.getParams());
             int code = request.code();
-            String body = request.body(CHARSET);
             JSONObject response = new JSONObject();
             this.addResponseHeaders(request, response);
             response.put("status", code);
             if (code >= 200 && code < 300) {
-                response.put("data", body);
+                // no 'body' to return for HEAD request
                 this.getCallbackContext().success(response);
             } else {
+                String body = request.body(CHARSET);
                 response.put("error", body);
                 this.getCallbackContext().error(response);
             }
         } catch (JSONException e) {
             this.respondWithError("There was an error generating the response");
-        }  catch (HttpRequestException e) {
+        } catch (HttpRequestException e) {
             if (e.getCause() instanceof UnknownHostException) {
                 this.respondWithError(0, "The host could not be resolved");
             } else if (e.getCause() instanceof SSLHandshakeException) {

--- a/src/android/com/synconset/CordovaHTTP/CordovaHttpPlugin.java
+++ b/src/android/com/synconset/CordovaHTTP/CordovaHttpPlugin.java
@@ -58,6 +58,14 @@ public class CordovaHttpPlugin extends CordovaPlugin {
             HashMap<String, String> headersMap = this.addToMap(this.globalHeaders, headers);
             CordovaHttpGet get = new CordovaHttpGet(urlString, paramsMap, headersMap, callbackContext);
             cordova.getThreadPool().execute(get);
+        } else if (action.equals("head")) {
+            String urlString = args.getString(0);
+            JSONObject params = args.getJSONObject(1);
+            JSONObject headers = args.getJSONObject(2);
+            HashMap<?, ?> paramsMap = this.getMapFromJSONObject(params);
+            HashMap<String, String> headersMap = this.addToMap(this.globalHeaders, headers);
+            CordovaHttpHead head = new CordovaHttpHead(urlString, paramsMap, headersMap, callbackContext);
+            cordova.getThreadPool().execute(head);
         } else if (action.equals("post")) {
             String urlString = args.getString(0);
             JSONObject params = args.getJSONObject(1);

--- a/src/android/com/synconset/CordovaHTTP/CordovaHttpPlugin.java
+++ b/src/android/com/synconset/CordovaHTTP/CordovaHttpPlugin.java
@@ -84,6 +84,10 @@ public class CordovaHttpPlugin extends CordovaPlugin {
             boolean accept = args.getBoolean(0);
             CordovaHttp.acceptAllCerts(accept);
             callbackContext.success();
+        } else if (action.equals("acceptAllHosts")) {
+            boolean accept = args.getBoolean(0);
+            CordovaHttp.acceptAllHosts(accept);
+            callbackContext.success();
         } else if (action.equals("setHeader")) {
             String header = args.getString(0);
             String value = args.getString(1);

--- a/src/android/com/synconset/CordovaHTTP/CordovaHttpPlugin.java
+++ b/src/android/com/synconset/CordovaHTTP/CordovaHttpPlugin.java
@@ -83,6 +83,7 @@ public class CordovaHttpPlugin extends CordovaPlugin {
         } else if (action.equals("acceptAllCerts")) {
             boolean accept = args.getBoolean(0);
             CordovaHttp.acceptAllCerts(accept);
+            callbackContext.success();
         } else if (action.equals("setHeader")) {
             String header = args.getString(0);
             String value = args.getString(1);

--- a/src/android/com/synconset/CordovaHTTP/CordovaHttpUpload.java
+++ b/src/android/com/synconset/CordovaHTTP/CordovaHttpUpload.java
@@ -70,6 +70,7 @@ public class CordovaHttpUpload extends CordovaHttp implements Runnable {
             String body = request.body(CHARSET);
             
             JSONObject response = new JSONObject();
+            this.addResponseHeaders(request, response);
             response.put("status", code);
             if (code >= 200 && code < 300) {
                 response.put("data", body);

--- a/src/android/com/synconset/CordovaHTTP/HttpRequest.java
+++ b/src/android/com/synconset/CordovaHTTP/HttpRequest.java
@@ -3252,11 +3252,17 @@ public class HttpRequest {
    *
    * @return this request
    */
-  public HttpRequest trustAllHosts() {
+  public HttpRequest trustAllHosts(boolean enable) {
     final HttpURLConnection connection = getConnection();
-    if (connection instanceof HttpsURLConnection)
-      ((HttpsURLConnection) connection)
-          .setHostnameVerifier(getTrustedVerifier());
+    if (connection instanceof HttpsURLConnection) {
+      if (enable) {
+        ((HttpsURLConnection) connection)
+            .setHostnameVerifier(getTrustedVerifier());
+      } else {
+        ((HttpsURLConnection) connection)
+                .setHostnameVerifier(HttpsURLConnection.getDefaultHostnameVerifier());
+      }
+    }
     return this;
   }
 

--- a/src/ios/CordovaHttpPlugin.h
+++ b/src/ios/CordovaHttpPlugin.h
@@ -9,6 +9,7 @@
 - (void)setHeader:(CDVInvokedUrlCommand*)command;
 - (void)enableSSLPinning:(CDVInvokedUrlCommand*)command;
 - (void)acceptAllCerts:(CDVInvokedUrlCommand*)command;
+- (void)acceptAllHosts:(CDVInvokedUrlCommand*)command;
 - (void)post:(CDVInvokedUrlCommand*)command;
 - (void)get:(CDVInvokedUrlCommand*)command;
 - (void)uploadFile:(CDVInvokedUrlCommand*)command;

--- a/src/ios/CordovaHttpPlugin.h
+++ b/src/ios/CordovaHttpPlugin.h
@@ -1,7 +1,6 @@
 #import <Foundation/Foundation.h>
 
 #import <Cordova/CDVPlugin.h>
-#import <Cordova/CDVJSON.h>
 
 @interface CordovaHttpPlugin : CDVPlugin
 

--- a/src/ios/CordovaHttpPlugin.m
+++ b/src/ios/CordovaHttpPlugin.m
@@ -91,12 +91,18 @@
    [manager POST:url parameters:parameters success:^(AFHTTPRequestOperation *operation, id responseObject) {
       NSMutableDictionary *dictionary = [NSMutableDictionary dictionary];
       [dictionary setObject:[NSNumber numberWithInt:operation.response.statusCode] forKey:@"status"];
+      if (operation.response != nil) {
+         [dictionary setObject:operation.response.allHeaderFields forKey:@"headers"];
+      }
       [dictionary setObject:responseObject forKey:@"data"];
       CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:dictionary];
       [weakSelf.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
    } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
       NSMutableDictionary *dictionary = [NSMutableDictionary dictionary];
       [dictionary setObject:[NSNumber numberWithInt:operation.response.statusCode] forKey:@"status"];
+      if (operation.response != nil) {
+         [dictionary setObject:operation.response.allHeaderFields forKey:@"headers"];
+      }
       [dictionary setObject:[error localizedDescription] forKey:@"error"];
       CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:dictionary];
       [weakSelf.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
@@ -116,16 +122,53 @@
    [manager GET:url parameters:parameters success:^(AFHTTPRequestOperation *operation, id responseObject) {
       NSMutableDictionary *dictionary = [NSMutableDictionary dictionary];
       [dictionary setObject:[NSNumber numberWithInt:operation.response.statusCode] forKey:@"status"];
+      if (operation.response != nil) {
+         [dictionary setObject:operation.response.allHeaderFields forKey:@"headers"];
+      }
       [dictionary setObject:responseObject forKey:@"data"];
       CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:dictionary];
       [weakSelf.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
    } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
       NSMutableDictionary *dictionary = [NSMutableDictionary dictionary];
       [dictionary setObject:[NSNumber numberWithInt:operation.response.statusCode] forKey:@"status"];
+      if (operation.response != nil) {
+         [dictionary setObject:operation.response.allHeaderFields forKey:@"headers"];
+      }
       [dictionary setObject:[error localizedDescription] forKey:@"error"];
       CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:dictionary];
       [weakSelf.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
    }];
+}
+
+- (void)head:(CDVInvokedUrlCommand*)command {
+    HttpManager *manager = [HttpManager sharedClient];
+    NSString *url = [command.arguments objectAtIndex:0];
+    NSDictionary *parameters = [command.arguments objectAtIndex:1];
+    NSDictionary *headers = [command.arguments objectAtIndex:2];
+    [self setRequestHeaders: headers];
+    
+    CordovaHttpPlugin* __weak weakSelf = self;
+    
+    manager.responseSerializer = [AFHTTPResponseSerializer serializer];
+    [manager HEAD:url parameters:parameters success:^(AFHTTPRequestOperation *operation) {
+        NSMutableDictionary *dictionary = [NSMutableDictionary dictionary];
+        [dictionary setObject:[NSNumber numberWithInt:operation.response.statusCode] forKey:@"status"];
+        if (operation.response != nil) {
+            [dictionary setObject:operation.response.allHeaderFields forKey:@"headers"];
+        }
+        // no 'body' for HEAD request, omitting 'data'
+        CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:dictionary];
+        [weakSelf.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+    } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+        NSMutableDictionary *dictionary = [NSMutableDictionary dictionary];
+        [dictionary setObject:[NSNumber numberWithInt:operation.response.statusCode] forKey:@"status"];
+        if (operation.response != nil) {
+            [dictionary setObject:operation.response.allHeaderFields forKey:@"headers"];
+        }
+        [dictionary setObject:[error localizedDescription] forKey:@"error"];
+        CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:dictionary];
+        [weakSelf.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+    }];
 }
 
 - (void)uploadFile:(CDVInvokedUrlCommand*)command {
@@ -156,11 +199,17 @@
     } success:^(AFHTTPRequestOperation *operation, id responseObject) {
         NSMutableDictionary *dictionary = [NSMutableDictionary dictionary];
         [dictionary setObject:[NSNumber numberWithInt:operation.response.statusCode] forKey:@"status"];
+        if (operation.response != nil) {
+            [dictionary setObject:operation.response.allHeaderFields forKey:@"headers"];
+        }
         CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:dictionary];
         [weakSelf.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
     } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
         NSMutableDictionary *dictionary = [NSMutableDictionary dictionary];
         [dictionary setObject:[NSNumber numberWithInt:operation.response.statusCode] forKey:@"status"];
+        if (operation.response != nil) {
+            [dictionary setObject:operation.response.allHeaderFields forKey:@"headers"];
+        }
         [dictionary setObject:[error localizedDescription] forKey:@"error"];
         CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:dictionary];
         [weakSelf.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
@@ -236,12 +285,18 @@
         id filePlugin = [self.commandDelegate getCommandInstance:@"File"];
         NSMutableDictionary *dictionary = [NSMutableDictionary dictionary];
         [dictionary setObject:[NSNumber numberWithInt:operation.response.statusCode] forKey:@"status"];
+        if (operation.response != nil) {
+            [dictionary setObject:operation.response.allHeaderFields forKey:@"headers"];
+        }
         [dictionary setObject:[filePlugin getDirectoryEntry:filePath isDirectory:NO] forKey:@"file"];
         CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:dictionary];
         [weakSelf.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
     } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
         NSMutableDictionary *dictionary = [NSMutableDictionary dictionary];
         [dictionary setObject:[NSNumber numberWithInt:operation.response.statusCode] forKey:@"status"];
+        if (operation.response != nil) {
+            [dictionary setObject:operation.response.allHeaderFields forKey:@"headers"];
+        }
         [dictionary setObject:[error localizedDescription] forKey:@"error"];
         CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:dictionary];
         [weakSelf.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];

--- a/src/ios/CordovaHttpPlugin.m
+++ b/src/ios/CordovaHttpPlugin.m
@@ -71,6 +71,14 @@
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
+- (void)acceptAllHosts:(CDVInvokedUrlCommand*)command {
+    CDVPluginResult* pluginResult = nil;
+    bool allow = [[command.arguments objectAtIndex:0] boolValue];
+    [HttpManager sharedClient].securityPolicy.validatesDomainName = !allow;
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+}
+
 - (void)post:(CDVInvokedUrlCommand*)command {
    HttpManager *manager = [HttpManager sharedClient];
    NSString *url = [command.arguments objectAtIndex:0];

--- a/src/ios/CordovaHttpPlugin.m
+++ b/src/ios/CordovaHttpPlugin.m
@@ -177,6 +177,10 @@
    
     [self setRequestHeaders: headers];
     
+    if ([filePath hasPrefix:@"file://"]) {
+        filePath = [filePath substringFromIndex:7];
+    }
+    
     CordovaHttpPlugin* __weak weakSelf = self;
     manager.responseSerializer = [AFHTTPResponseSerializer serializer];
     [manager GET:url parameters:parameters success:^(AFHTTPRequestOperation *operation, id responseObject) {
@@ -229,10 +233,10 @@
             return;
         }
    
-        CDVFile *file = [[CDVFile alloc] init];
+        id filePlugin = [self.commandDelegate getCommandInstance:@"File"];
         NSMutableDictionary *dictionary = [NSMutableDictionary dictionary];
         [dictionary setObject:[NSNumber numberWithInt:operation.response.statusCode] forKey:@"status"];
-        [dictionary setObject:[file getDirectoryEntry:filePath isDirectory:NO] forKey:@"file"];
+        [dictionary setObject:[filePlugin getDirectoryEntry:filePath isDirectory:NO] forKey:@"file"];
         CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:dictionary];
         [weakSelf.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
     } failure:^(AFHTTPRequestOperation *operation, NSError *error) {

--- a/www/cordovaHTTP.js
+++ b/www/cordovaHTTP.js
@@ -28,6 +28,9 @@ var http = {
     get: function(url, params, headers, success, failure) {
         return exec(success, failure, "CordovaHttpPlugin", "get", [url, params, headers]);
     },
+    head: function(url, params, headers, success, failure) {
+        return exec(success, failure, "CordovaHttpPlugin", "head", [url, params, headers]);
+    },
     uploadFile: function(url, params, headers, filePath, name, success, failure) {
         return exec(success, failure, "CordovaHttpPlugin", "uploadFile", [url, params, headers, filePath, name]);
     },
@@ -121,6 +124,9 @@ if (typeof angular !== "undefined") {
             },
             get: function(url, params, headers) {
                 return makePromise(http.get, [url, params, headers], true);
+            },
+            head: function(url, params, headers) {
+                return makePromise(http.head, [url, params, headers], true);
             },
             uploadFile: function(url, params, headers, filePath, name) {
                 return makePromise(http.uploadFile, [url, params, headers, filePath, name], true);

--- a/www/cordovaHTTP.js
+++ b/www/cordovaHTTP.js
@@ -19,6 +19,9 @@ var http = {
     acceptAllCerts: function(allow, success, failure) {
         return exec(success, failure, "CordovaHttpPlugin", "acceptAllCerts", [allow]);
     },
+    acceptAllHosts: function(allow, success, failure) {
+        return exec(success, failure, "CordovaHttpPlugin", "acceptAllHosts", [allow]);
+    },
     post: function(url, params, headers, success, failure) {
         return exec(success, failure, "CordovaHttpPlugin", "post", [url, params, headers]);
     },

--- a/www/cordovaHTTP.js
+++ b/www/cordovaHTTP.js
@@ -52,11 +52,13 @@ var http = {
          *
         */
         var win = function(result) {
-            var entry = new (require('org.apache.cordova.file.FileEntry'))();
+            var entry = new (require('cordova-plugin-file.FileEntry'))();
             entry.isDirectory = false;
             entry.isFile = true;
             entry.name = result.file.name;
             entry.fullPath = result.file.fullPath;
+            entry.filesystem = new FileSystem(result.file.filesystemName || (result.file.filesystem == window.PERSISTENT ? 'persistent' : 'temporary'));
+            entry.nativeURL = result.file.nativeURL;
             success(entry);
         };
         return exec(win, failure, "CordovaHttpPlugin", "downloadFile", [url, params, headers, filePath]);


### PR DESCRIPTION
In reference to issue #19 I updated the dependencies for cordova file plugin and did some initial testing in android. Updated java source to not use the now deprecated getEntry() function, also added missing properties on file entry in js so that it references the proper filesystem/URL.

It might make sense to merge this in a separate branch and/or properly document the last version that supports the old plugin for those needing it. In any case I'll leave this in your hands to do what you wish.

Cheers
Denis