### PR TITLE
Add support for angular strict dependency injection mode

### DIFF
--- a/www/cordovaHTTP.js
+++ b/www/cordovaHTTP.js
@@ -103,7 +103,7 @@ var http = {
 module.exports = http;
 
 if (typeof angular !== "undefined") {
-    angular.module('cordovaHTTP', []).factory('cordovaHTTP', function($timeout, $q) {
+    angular.module('cordovaHTTP', []).factory('cordovaHTTP', ['$timeout', '$q', function($timeout, $q) {
         function makePromise(fn, args, async) {
             var deferred = $q.defer();
             
@@ -169,7 +169,7 @@ if (typeof angular !== "undefined") {
             }
         };
         return cordovaHTTP;
-    });
+    }]);
 } else {
     window.cordovaHTTP = http;
 }


### PR DESCRIPTION
If the plugin is imported in an Angular JS app bootstrapped with the `strictDi` option enabled (strict mode), the dependencies of `cordovaHTTP` factory must be injected using the [explicit annotation](https://docs.angularjs.org/error/$injector/strictdi), otherwise the execution is stopped.