### PR TITLE
Allow usage of "Accept" header on iOS

### DIFF
--- a/src/ios/CordovaHttpPlugin.m
+++ b/src/ios/CordovaHttpPlugin.m
@@ -75,7 +75,7 @@
     [self setRequestHeaders: headers forManager: manager];
    
     CordovaHttpPlugin* __weak weakSelf = self;
-    manager.responseSerializer = [TextResponseSerializer serializer];
+    manager.responseSerializer = [TextResponseSerializer serializer: headers];
     [manager POST:url parameters:parameters progress:nil success:^(NSURLSessionTask *task, id responseObject) {
         NSMutableDictionary *dictionary = [NSMutableDictionary dictionary];
         [self setResults: dictionary withTask: task];
@@ -102,7 +102,7 @@
    
     CordovaHttpPlugin* __weak weakSelf = self;
    
-    manager.responseSerializer = [TextResponseSerializer serializer];
+    manager.responseSerializer = [TextResponseSerializer serializer: headers];
     [manager GET:url parameters:parameters progress:nil success:^(NSURLSessionTask *task, id responseObject) {
         NSMutableDictionary *dictionary = [NSMutableDictionary dictionary];
         [self setResults: dictionary withTask: task];
@@ -160,7 +160,7 @@
     [self setRequestHeaders: headers forManager: manager];
     
     CordovaHttpPlugin* __weak weakSelf = self;
-    manager.responseSerializer = [TextResponseSerializer serializer];
+    manager.responseSerializer = [TextResponseSerializer serializer: headers];
     [manager POST:url parameters:parameters constructingBodyWithBlock:^(id<AFMultipartFormData> formData) {
         NSError *error;
         [formData appendPartWithFileURL:fileURL name:name error:&error];

--- a/src/ios/TextResponseSerializer.h
+++ b/src/ios/TextResponseSerializer.h
@@ -3,6 +3,6 @@
 
 @interface TextResponseSerializer : AFHTTPResponseSerializer
 
-+ (instancetype)serializer;
++ (instancetype)serializer:(NSDictionary*)headers;
 
 @end

--- a/src/ios/TextResponseSerializer.m
+++ b/src/ios/TextResponseSerializer.m
@@ -12,18 +12,25 @@ static BOOL AFErrorOrUnderlyingErrorHasCodeInDomain(NSError *error, NSInteger co
 
 @implementation TextResponseSerializer
 
-+ (instancetype)serializer {
-    TextResponseSerializer *serializer = [[self alloc] init];
++ (instancetype)serializer:(NSDictionary *)headers {
+    TextResponseSerializer *serializer = [[self alloc] init: headers];
     return serializer;
 }
 
-- (instancetype)init {
+- (instancetype)init:(NSDictionary *)headers {
     self = [super init];
     if (!self) {
         return nil;
     }
 
     self.acceptableContentTypes = [NSSet setWithObjects:@"text/plain", @"text/html", @"text/json", @"application/json", @"text/xml", @"application/xml", @"text/css", nil];
+
+    if ([headers objectForKey:@"Accept"]) {
+        NSString *acceptHeader = [headers valueForKeyPath:@"Accept"];
+        acceptHeader = [acceptHeader stringByReplacingOccurrencesOfString:@" " withString:@""];
+        NSArray *acceptHeaderList = [acceptHeader componentsSeparatedByString:@","];
+        self.acceptableContentTypes = [self.acceptableContentTypes setByAddingObjectsFromArray:acceptHeaderList];
+    }
 
     return self;
 }


### PR DESCRIPTION
On iOS, the accepted content-types of the http response are hard-coded in TextResponseSerializer, which makes impossible to customize them without forking the repo.

This commit adds the possibility to extend the Set of the acceptableContentTypes, using the Accept header from the http request. So, any content-type(s) sent in that header will be added to the accepted ones. Without this change, the Accept header would be working as expected on Android, but not on iOS, creating a risky inconsistency.
The fastest way I found to get this done was to pass the header Dictionary to the TextResponseSerializer serializer method, but maybe somebody has a cleaner way to do the same, please have a look.

Warning: just as a reminder, since this code changes the +serializer signature, if new methods are added to CordovaHttpPlugin implementation (e.g with the [PR#105](https://github.com/wymsee/cordova-HTTP/pull/105)), calls to serializer needs to be adapted.