### PR TITLE
Add global redirection control

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ This sets up all future requests to use Basic HTTP authentication with the given
 Set a header for all future requests.  Takes a header and a value.
 
     cordovaHTTP.setHeader("Header", "Value");
+
+### disableRedirect
+If set to `true`, it won't follow redirects automatically. This is a global setting.
+
+    cordovaHTTP.disableRedirect(true);
     
 
 ## Async Functions

--- a/src/android/com/synconset/CordovaHTTP/CordovaHttp.java
+++ b/src/android/com/synconset/CordovaHTTP/CordovaHttp.java
@@ -38,6 +38,7 @@ public abstract class CordovaHttp {
     private static AtomicBoolean sslPinning = new AtomicBoolean(false);
     private static AtomicBoolean acceptAllCerts = new AtomicBoolean(false);
     private static AtomicBoolean validateDomainName = new AtomicBoolean(true);
+    private static AtomicBoolean disableRedirect = new AtomicBoolean(false);
 
     private String urlString;
     private Map<?, ?> params;
@@ -69,6 +70,10 @@ public abstract class CordovaHttp {
         validateDomainName.set(accept);
     }
 
+    public static void disableRedirect(boolean disable) {
+        disableRedirect.set(disable);
+    }
+
     protected String getUrlString() {
         return this.urlString;
     }
@@ -95,6 +100,14 @@ public abstract class CordovaHttp {
         if (sslPinning.get()) {
             request.pinToCerts();
         }
+        return request;
+    }
+
+    protected HttpRequest setupRedirect(HttpRequest request) {
+        if (disableRedirect.get()) {
+            request.followRedirects(false);
+        }
+
         return request;
     }
     

--- a/src/android/com/synconset/CordovaHTTP/CordovaHttpDownload.java
+++ b/src/android/com/synconset/CordovaHTTP/CordovaHttpDownload.java
@@ -34,6 +34,7 @@ public class CordovaHttpDownload extends CordovaHttp implements Runnable {
     public void run() {
         try {
             HttpRequest request = HttpRequest.get(this.getUrlString(), this.getParams(), true);
+            this.setupRedirect(request);
             this.setupSecurity(request);
             request.acceptCharset(CHARSET);
             request.headers(this.getHeaders());

--- a/src/android/com/synconset/CordovaHTTP/CordovaHttpGet.java
+++ b/src/android/com/synconset/CordovaHTTP/CordovaHttpGet.java
@@ -34,6 +34,7 @@ public class CordovaHttpGet extends CordovaHttp implements Runnable {
     public void run() {
         try {
             HttpRequest request = HttpRequest.get(this.getUrlString(), this.getParams(), false);
+            this.setupRedirect(request);
             this.setupSecurity(request);
             request.acceptCharset(CHARSET);
             request.headers(this.getHeaders());

--- a/src/android/com/synconset/CordovaHTTP/CordovaHttpHead.java
+++ b/src/android/com/synconset/CordovaHTTP/CordovaHttpHead.java
@@ -34,6 +34,7 @@ public class CordovaHttpHead extends CordovaHttp implements Runnable {
     public void run() {
         try {
             HttpRequest request = HttpRequest.head(this.getUrlString(), this.getParams(), true);
+            this.setupRedirect(request);
             this.setupSecurity(request);
             request.acceptCharset(CHARSET);
             request.headers(this.getHeaders());

--- a/src/android/com/synconset/CordovaHTTP/CordovaHttpPlugin.java
+++ b/src/android/com/synconset/CordovaHTTP/CordovaHttpPlugin.java
@@ -107,6 +107,10 @@ public class CordovaHttpPlugin extends CordovaPlugin {
             String filePath = args.getString(3);
             CordovaHttpDownload download = new CordovaHttpDownload(urlString, paramsMap, headersMap, callbackContext, filePath);
             cordova.getThreadPool().execute(download);
+        } else if (action.equals("disableRedirect")) {
+            boolean disable = args.getBoolean(0);
+            CordovaHttp.disableRedirect = disable;
+            callbackContext.success();
         } else {
             return false;
         }

--- a/src/android/com/synconset/CordovaHTTP/CordovaHttpPlugin.java
+++ b/src/android/com/synconset/CordovaHTTP/CordovaHttpPlugin.java
@@ -109,7 +109,7 @@ public class CordovaHttpPlugin extends CordovaPlugin {
             cordova.getThreadPool().execute(download);
         } else if (action.equals("disableRedirect")) {
             boolean disable = args.getBoolean(0);
-            CordovaHttp.disableRedirect = disable;
+            CordovaHttp.disableRedirect(disable);
             callbackContext.success();
         } else {
             return false;

--- a/src/android/com/synconset/CordovaHTTP/CordovaHttpPost.java
+++ b/src/android/com/synconset/CordovaHTTP/CordovaHttpPost.java
@@ -26,6 +26,7 @@ public class CordovaHttpPost extends CordovaHttp implements Runnable {
     public void run() {
         try {
             HttpRequest request = HttpRequest.post(this.getUrlString());
+            this.setupRedirect(request);
             this.setupSecurity(request);
             request.acceptCharset(CHARSET);
             request.headers(this.getHeaders());

--- a/src/android/com/synconset/CordovaHTTP/CordovaHttpUpload.java
+++ b/src/android/com/synconset/CordovaHTTP/CordovaHttpUpload.java
@@ -38,6 +38,7 @@ public class CordovaHttpUpload extends CordovaHttp implements Runnable {
     public void run() {
         try {
             HttpRequest request = HttpRequest.post(this.getUrlString());
+            this.setupRedirect(request);
             this.setupSecurity(request);
             request.acceptCharset(CHARSET);
             request.headers(this.getHeaders());

--- a/src/ios/CordovaHttpPlugin.h
+++ b/src/ios/CordovaHttpPlugin.h
@@ -7,6 +7,7 @@
 - (void)enableSSLPinning:(CDVInvokedUrlCommand*)command;
 - (void)acceptAllCerts:(CDVInvokedUrlCommand*)command;
 - (void)validateDomainName:(CDVInvokedUrlCommand*)command;
+- (void)disableRedirect:(CDVInvokedUrlCommand*)command;
 - (void)post:(CDVInvokedUrlCommand*)command;
 - (void)get:(CDVInvokedUrlCommand*)command;
 - (void)uploadFile:(CDVInvokedUrlCommand*)command;

--- a/src/ios/CordovaHttpPlugin.m
+++ b/src/ios/CordovaHttpPlugin.m
@@ -40,11 +40,11 @@
 - (void)setRedirect:(AFHTTPSessionManager*)manager {
     [manager setTaskWillPerformHTTPRedirectionBlock:^NSURLRequest * _Nonnull(NSURLSession * _Nonnull session, NSURLSessionTask * _Nonnull task, NSURLResponse * _Nonnull response, NSURLRequest * _Nonnull request) {
         if (redirect) {
-            return redirect;
+            return request;
         } else {
             return nil;
         }
-    }
+    }];
 }
 
 - (void)enableSSLPinning:(CDVInvokedUrlCommand*)command {

--- a/www/cordovaHTTP.js
+++ b/www/cordovaHTTP.js
@@ -43,6 +43,9 @@ var http = {
     acceptAllCerts: function(allow, success, failure) {
         return exec(success, failure, "CordovaHttpPlugin", "acceptAllCerts", [allow]);
     },
+    disableRedirect: function(disable, success, failure) {
+        return exec(success, failure, "CordovaHttpPlugin", "disableRedirect", [disable]);
+    },
     validateDomainName: function(validate, success, failure) {
         return exec(success, failure, "CordovaHttpPlugin", "validateDomainName", [validate]);
     },
@@ -145,6 +148,9 @@ if (typeof angular !== "undefined") {
             },
             enableSSLPinning: function(enable) {
                 return makePromise(http.enableSSLPinning, [enable]);
+            },
+            disableRedirect: function(disable) {
+                return makePromise(http.disableRedirect, [disable]);
             },
             acceptAllCerts: function(allow) {
                 return makePromise(http.acceptAllCerts, [allow]);


### PR DESCRIPTION
In our project, we need to get the `Location` header of the `301` response from server, but both `XMLHttpRequest` and this plugin follow redirection automatically, so we modified this plugin to make it able to disable redirection following and re-enable it later.
A new option `disableRedirect` was added in this PR.
This code has been tested on our project.
